### PR TITLE
Allow rule templates from other cookbooks to be used by auditd_ruleset.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ based on the ruleset desired, one of:
 
 * "capp" : Controlled Access Protection Profile
 * "lspp" : Labeled Security Protection Profile
-* "nispom" : National Industrial Security Program Operating Manual (NISPOM) 
-* "stig" : Security Technical Implementation Guides 
+* "nispom" : National Industrial Security Program Operating Manual (NISPOM)
+* "stig" : Security Technical Implementation Guides
 * "cis"  : Center for Internet Security auditd recommendations
 
 And include `recipe[auditd::rules]` in your run list. You can also set
@@ -40,7 +40,11 @@ template to be used instead of one of the default rules.
 
 If you are using the recipe from a wrapper cookbook, include the
 default recipe `recipe[auditd]` to setup the service and use the
-`auditd_ruleset` resource to place your custom rule template.
+`auditd_ruleset` resource to place your rule template of choice.
+
+If you are not satisfied with any of the provided templates, you can
+specify the `cookbook` attribute in `auditd_ruleset` to use your own
+set of rules. In this case, do not include `recipe[auditd::rules]`.
 
 TODO
 ====

--- a/providers/ruleset.rb
+++ b/providers/ruleset.rb
@@ -21,6 +21,7 @@
 action :create do
   template '/etc/audit/audit.rules' do
     source "#{new_resource.name}.erb"
+    cookbook new_resource.cookbook if new_resource.cookbook
     notifies :restart, resources(service: 'auditd')
   end
 end

--- a/resources/ruleset.rb
+++ b/resources/ruleset.rb
@@ -27,3 +27,4 @@ def initialize(*args)
 end
 
 attribute :name, kind_of: String, name_attribute: true
+attribute :cookbook, kind_of: String, default: nil


### PR DESCRIPTION
When a user is not satisfied with any of the provided templates and
does not want to drop new files into this cookbook (thus modifying it),
let them specify a rule template residing in a wrapper cookbook.