### PR TITLE
use correct restart command when under systemd on rhel

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -27,6 +27,9 @@ else
 end
 
 service 'auditd' do
-  supports [:restart, :reload, :status]
+  supports [:start, :stop, :restart, :reload, :status]
+  if node['platform_family'] == 'rhel' && node['platform_version'].to_f >= 7
+    restart_command 'service auditd restart'
+  end
   action :enable
 end


### PR DESCRIPTION
the auditd process fails to restart correctly using sysctl to restart the service. this allows the service to be restarted on rhel / systemd systems > 7.0

